### PR TITLE
Update run_jaqket_baseline_sample.sh

### DIFF
--- a/run_jaqket_baseline_sample.sh
+++ b/run_jaqket_baseline_sample.sh
@@ -35,6 +35,7 @@ python ../JAQKET_baseline/jaqket_baseline.py \
   --dev_fname  ${DEV}  \
   --test_fname ${TEST} \
   --task_name jaqket \
+  --entities_fname ${ENTITY} \
   --model_name_or_path ${OUTDIR} \
   --eval_num_options 20 \
   --per_gpu_eval_batch_size 4 \


### PR DESCRIPTION
When I run the script `run_jaqket_baseline_sample.sh`, the following error occured.

```
04/22/2020 23:42:30 - INFO - __main__ -   LOOKING AT ../data/ entities
Traceback (most recent call last):
  File "../JAQKET_baseline/jaqket_baseline.py", line 1094, in <module>
    results = main()
  File "../JAQKET_baseline/jaqket_baseline.py", line 1065, in main
    result = evaluate(args, model, tokenizer, prefix=prefix)
  File "../JAQKET_baseline/jaqket_baseline.py", line 628, in evaluate
    args, eval_task, tokenizer, evaluate=not test, test=test
  File "../JAQKET_baseline/jaqket_baseline.py", line 747, in load_and_cache_examples
    num_options=args.eval_num_options,
  File "../JAQKET_baseline/jaqket_baseline.py", line 112, in get_examples
    entities = self._get_entities(data_dir, entities_fname)
  File "../JAQKET_baseline/jaqket_baseline.py", line 103, in _get_entities
    for line in self._read_json_gzip(os.path.join(data_dir, entities_fname)):
  File "../JAQKET_baseline/jaqket_baseline.py", line 151, in _read_json_gzip
    with gzip.open(input_file, "rt", encoding="utf-8") as fin:
  File "/usr/lib/python3.6/gzip.py", line 53, in open
    binary_file = GzipFile(filename, gz_mode, compresslevel)
  File "/usr/lib/python3.6/gzip.py", line 163, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: '../data/candidate_entities.json'
```

It seems that `--entities_fname` option is necessary. 

Another choice is to fix default value of `--entities_fname` in [python file](https://github.com/cl-tohoku/JAQKET_baseline/blob/master/jaqket_baseline.py#L833). In this case `--entities_fname` is not required even for training phase.