### PR TITLE
Use train_iterator.close() instead of epoch_iterator

### DIFF
--- a/jaqket_baseline.py
+++ b/jaqket_baseline.py
@@ -605,7 +605,7 @@ def train(args, train_dataset, model, tokenizer):
                     output_dir)
             # save model END
             if args.max_steps > 0 and global_step > args.max_steps:
-                epoch_iterator.close()
+                train_iterator.close()
                 break
         if args.max_steps > 0 and global_step > args.max_steps:
             train_iterator.close()


### PR DESCRIPTION
I think this PR would resolve following issue:
https://github.com/cl-tohoku/JAQKET_baseline/issues/2

Could you take a look at it?